### PR TITLE
Added distinction between a RowMapper and a ResultSetMapper.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     </repositories>
 
     <properties>
-        <storm.version>0.9.0-rc2</storm.version>
+        <storm.version>0.9.1-incubating</storm.version>
         <cassandra.version>1.2.5</cassandra.version>
     </properties>
 
@@ -58,8 +58,8 @@
             <version>1.6.4</version>
         </dependency>
         <dependency>
-            <groupId>storm</groupId>
-            <artifactId>storm</artifactId>
+            <groupId>org.apache.storm</groupId>
+            <artifactId>storm-core</artifactId>
             <version>${storm.version}</version>
             <!-- keep storm out of the jar-with-dependencies -->
             <scope>provided</scope>

--- a/src/main/java/com/hmsonline/trident/cql/CassandraCqlMapStateFactory.java
+++ b/src/main/java/com/hmsonline/trident/cql/CassandraCqlMapStateFactory.java
@@ -1,14 +1,21 @@
 package com.hmsonline.trident.cql;
 
-import backtype.storm.task.IMetricsContext;
-import backtype.storm.tuple.Values;
-import com.hmsonline.trident.cql.CassandraCqlMapState.Options;
+import java.util.Map;
+
 import storm.trident.state.State;
 import storm.trident.state.StateFactory;
 import storm.trident.state.StateType;
-import storm.trident.state.map.*;
+import storm.trident.state.map.CachedMap;
+import storm.trident.state.map.MapState;
+import storm.trident.state.map.NonTransactionalMap;
+import storm.trident.state.map.OpaqueMap;
+import storm.trident.state.map.SnapshottableMap;
+import storm.trident.state.map.TransactionalMap;
+import backtype.storm.task.IMetricsContext;
+import backtype.storm.tuple.Values;
 
-import java.util.Map;
+import com.hmsonline.trident.cql.CassandraCqlMapState.Options;
+import com.hmsonline.trident.cql.mappers.CqlRowMapper;
 
 /**
  * The class responsible for generating instances of
@@ -24,10 +31,10 @@ public class CassandraCqlMapStateFactory implements StateFactory {
     private Options<?> options;
 
     @SuppressWarnings("rawtypes")
-    private CqlTupleMapper mapper;
+    private CqlRowMapper mapper;
 
     @SuppressWarnings({"rawtypes"})
-    public CassandraCqlMapStateFactory(CqlTupleMapper mapper, StateType stateType, Options options) {
+    public CassandraCqlMapStateFactory(CqlRowMapper mapper, StateType stateType, Options options) {
         this.stateType = stateType;
         this.options = options;
         this.mapper = mapper;

--- a/src/main/java/com/hmsonline/trident/cql/CassandraCqlState.java
+++ b/src/main/java/com/hmsonline/trident/cql/CassandraCqlState.java
@@ -1,14 +1,17 @@
 package com.hmsonline.trident.cql;
 
-import com.datastax.driver.core.BatchStatement;
-import com.datastax.driver.core.BatchStatement.Type;
-import com.datastax.driver.core.Statement;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import storm.trident.state.State;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import storm.trident.state.State;
+
+import com.datastax.driver.core.BatchStatement;
+import com.datastax.driver.core.BatchStatement.Type;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Statement;
 
 public class CassandraCqlState implements State {
     private static final Logger LOG = LoggerFactory.getLogger(CassandraCqlState.class);
@@ -34,5 +37,9 @@ public class CassandraCqlState implements State {
 
     public void addStatement(Statement statement) {
         this.statements.add(statement);
+    }
+    
+    public ResultSet execute(Statement statement){
+        return clientFactory.getSession().execute(statement);
     }
 }

--- a/src/main/java/com/hmsonline/trident/cql/CassandraCqlStateUpdater.java
+++ b/src/main/java/com/hmsonline/trident/cql/CassandraCqlStateUpdater.java
@@ -1,8 +1,11 @@
 package com.hmsonline.trident.cql;
 
 import com.datastax.driver.core.Statement;
+import com.hmsonline.trident.cql.mappers.CqlTupleMapper;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import storm.trident.operation.TridentCollector;
 import storm.trident.operation.TridentOperationContext;
 import storm.trident.state.StateUpdater;

--- a/src/main/java/com/hmsonline/trident/cql/CqlClientFactory.java
+++ b/src/main/java/com/hmsonline/trident/cql/CqlClientFactory.java
@@ -1,18 +1,21 @@
 package com.hmsonline.trident.cql;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.Session;
-import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
 
 /**
  * @author boneill
  */
-public class CqlClientFactory {
+public class CqlClientFactory implements Serializable {
+    private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(CqlClientFactory.class);
     private Map<String, Session> sessions = new HashMap<String, Session>();
     private Session defaultSession = null;

--- a/src/main/java/com/hmsonline/trident/cql/mappers/CqlRowMapper.java
+++ b/src/main/java/com/hmsonline/trident/cql/mappers/CqlRowMapper.java
@@ -1,0 +1,15 @@
+package com.hmsonline.trident.cql.mappers;
+
+import com.datastax.driver.core.Row;
+
+/**
+ * The <code>CqlRowMapper</code> interface extends <code>CqlTupleMapper</code> 
+ * with the ability to translate a single row into an object.
+ *
+ * @param K the key to map and retrieve
+ * @param V the value to map and retrieve
+ * @author boneill
+ */
+public abstract interface CqlRowMapper<K, V> extends CqlTupleMapper<K,V> {
+    public V getValue(Row row);
+}

--- a/src/main/java/com/hmsonline/trident/cql/mappers/CqlTupleMapper.java
+++ b/src/main/java/com/hmsonline/trident/cql/mappers/CqlTupleMapper.java
@@ -1,8 +1,8 @@
-package com.hmsonline.trident.cql;
+package com.hmsonline.trident.cql.mappers;
 
-import com.datastax.driver.core.Row;
-import com.datastax.driver.core.Statement;
 import storm.trident.tuple.TridentTuple;
+
+import com.datastax.driver.core.Statement;
 
 /**
  * The <code>CqlTupleMapper</code> interface is responsible
@@ -13,12 +13,10 @@ import storm.trident.tuple.TridentTuple;
  * @param V the value to map and retrieve
  * @author rlee
  */
-public interface CqlTupleMapper<K, V> {
+public abstract interface CqlTupleMapper<K, V> {
     public Statement map(K key, V value);
 
     public Statement map(TridentTuple tuple);
 
     public Statement retrieve(K key);
-
-    public V getValue(Row row);
 }

--- a/src/test/java/com/hmsonline/trident/cql/example/ExampleMapper.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/ExampleMapper.java
@@ -1,16 +1,19 @@
 package com.hmsonline.trident.cql.example;
 
-import com.datastax.driver.core.Row;
-import com.datastax.driver.core.Statement;
-import com.datastax.driver.core.querybuilder.Update;
-import com.hmsonline.trident.cql.CqlTupleMapper;
-import storm.trident.tuple.TridentTuple;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
 
 import java.io.Serializable;
 
-import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+import storm.trident.tuple.TridentTuple;
 
-public class ExampleMapper implements CqlTupleMapper, Serializable {
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.querybuilder.Update;
+import com.hmsonline.trident.cql.mappers.CqlRowMapper;
+
+public class ExampleMapper implements CqlRowMapper<Object, Object>, Serializable {
     private static final long serialVersionUID = 1L;
 
     public Statement map(TridentTuple tuple) {

--- a/src/test/java/com/hmsonline/trident/cql/example/wordcount/IntegerCount.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/wordcount/IntegerCount.java
@@ -5,6 +5,7 @@ import storm.trident.tuple.TridentTuple;
 
 
 public class IntegerCount implements CombinerAggregator<Integer> {
+    private static final long serialVersionUID = 1L;
 
     @Override
     public Integer init(TridentTuple tuple) {

--- a/src/test/java/com/hmsonline/trident/cql/example/wordcount/WordCountAndSourceMapper.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/wordcount/WordCountAndSourceMapper.java
@@ -1,21 +1,20 @@
 package com.hmsonline.trident.cql.example.wordcount;
 
+import java.io.Serializable;
+import java.util.List;
+
+import storm.trident.tuple.TridentTuple;
+
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.querybuilder.Insert;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.querybuilder.Select;
-import com.hmsonline.trident.cql.CqlTupleMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import storm.trident.tuple.TridentTuple;
+import com.hmsonline.trident.cql.mappers.CqlRowMapper;
 
-import java.io.Serializable;
-import java.util.List;
-
-public class WordCountAndSourceMapper implements CqlTupleMapper<List<String>, Number>, Serializable {
+public class WordCountAndSourceMapper implements CqlRowMapper<List<String>, Number>, Serializable {
     private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(WordCountAndSourceMapper.class);
+    //private static final Logger LOG = LoggerFactory.getLogger(WordCountAndSourceMapper.class);
 
     public static final String KEYSPACE_NAME = "mykeyspace";
     public static final String TABLE_NAME = "wordcounttable";

--- a/src/test/java/com/hmsonline/trident/cql/example/wordcount/WordCountMapper.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/wordcount/WordCountMapper.java
@@ -1,21 +1,20 @@
 package com.hmsonline.trident.cql.example.wordcount;
 
+import java.io.Serializable;
+import java.util.List;
+
+import storm.trident.tuple.TridentTuple;
+
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.querybuilder.Insert;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.querybuilder.Select;
-import com.hmsonline.trident.cql.CqlTupleMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import storm.trident.tuple.TridentTuple;
+import com.hmsonline.trident.cql.mappers.CqlRowMapper;
 
-import java.io.Serializable;
-import java.util.List;
-
-public class WordCountMapper implements CqlTupleMapper<List<String>, Number>, Serializable {
+public class WordCountMapper implements CqlRowMapper<List<String>, Number>, Serializable {
     private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(WordCountMapper.class);
+    //private static final Logger LOG = LoggerFactory.getLogger(WordCountMapper.class);
 
     public static final String KEYSPACE_NAME = "mykeyspace";
     public static final String TABLE_NAME = "wordcounttable";

--- a/src/test/java/com/hmsonline/trident/cql/incremental/example/SalesAnalyticsMapper.java
+++ b/src/test/java/com/hmsonline/trident/cql/incremental/example/SalesAnalyticsMapper.java
@@ -1,22 +1,23 @@
 package com.hmsonline.trident.cql.incremental.example;
 
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
+
+import java.io.Serializable;
+
+import storm.trident.tuple.TridentTuple;
+
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.querybuilder.Select;
 import com.datastax.driver.core.querybuilder.Update;
 import com.hmsonline.trident.cql.incremental.CqlIncrementMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import storm.trident.tuple.TridentTuple;
-
-import java.io.Serializable;
-
-import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 
 public class SalesAnalyticsMapper implements CqlIncrementMapper<String, Number>, Serializable {
     private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(SalesAnalyticsMapper.class);
+    //private static final Logger LOG = LoggerFactory.getLogger(SalesAnalyticsMapper.class);
 
     // values assumed by the schema.cql; should make customizable by constructor
     public static final String KEYSPACE_NAME = "mykeyspace";


### PR DESCRIPTION
Some data models require mapping the ResultSet, not just a single Row.  (where a single object is spread across multiple rows)  This change enables that.

(also up'd the storm version to the latest)
