### PR TITLE
Bump cassandra-driver-core dependency to 2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4
+
+* Bump cassandra-driver-core dependency to 2.1.4
+
 ## 0.2.1
 
 * [#27][]: Use QUORUM by default instead of LOCAL_QUORUM

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>2.1.3</version>
+            <version>2.1.4</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Specifically to receive this enhancement which is biting us: https://datastax-oss.atlassian.net/browse/JAVA-504