### PR TITLE
attempt to correct #37  - is CassandraCqlState leaking statments?

### DIFF
--- a/src/main/java/com/hmsonline/trident/cql/CassandraCqlState.java
+++ b/src/main/java/com/hmsonline/trident/cql/CassandraCqlState.java
@@ -53,6 +53,7 @@ public class CassandraCqlState implements State {
         if(i > 0) {
             clientFactory.getSession().execute(batch);
         }
+        this.statements.clear();
     }
 
     public void addStatement(Statement statement) {


### PR DESCRIPTION


Hello,

We are seeing degradation on performance with time.
So we are believing we have a leak somewhere.
Should not we have some sort of reset of the this.statements field in the end of the ```commit``` method :

https://github.com/hmsonline/storm-cassandra-cql/blob/master/src/main/java/com/hmsonline/trident/cql/CassandraCqlState.java#L56

```
this.statements.clear();
```

Thanks in advance,
Lucas
