### PR TITLE
Additional configuration options, additional tests, fixed examples.

### DIFF
--- a/src/main/java/com/hmsonline/trident/cql/CassandraCqlMapState.java
+++ b/src/main/java/com/hmsonline/trident/cql/CassandraCqlMapState.java
@@ -73,7 +73,7 @@ public class CassandraCqlMapState<T> implements IBackingMap<T> {
 
     @SuppressWarnings("rawtypes")
     public static StateFactory opaque(CqlRowMapper mapper, Options<OpaqueValue> opts) {
-        return new CassandraCqlMapStateFactory(mapper, StateType.OPAQUE, opts, ConsistencyLevel.QUORUM);
+        return new CassandraCqlMapStateFactory(mapper, StateType.OPAQUE, opts);
     }
 
     @SuppressWarnings("rawtypes")
@@ -84,7 +84,7 @@ public class CassandraCqlMapState<T> implements IBackingMap<T> {
 
     @SuppressWarnings("rawtypes")
     public static StateFactory transactional(CqlRowMapper mapper, Options<TransactionalValue> opts) {
-        return new CassandraCqlMapStateFactory(mapper, StateType.TRANSACTIONAL, opts, ConsistencyLevel.QUORUM);
+        return new CassandraCqlMapStateFactory(mapper, StateType.TRANSACTIONAL, opts);
     }
 
     @SuppressWarnings("rawtypes")
@@ -95,7 +95,7 @@ public class CassandraCqlMapState<T> implements IBackingMap<T> {
 
     @SuppressWarnings("rawtypes")
     public static StateFactory nonTransactional(CqlRowMapper mapper, Options<Object> opts) {
-        return new CassandraCqlMapStateFactory(mapper, StateType.NON_TRANSACTIONAL, opts, ConsistencyLevel.QUORUM);
+        return new CassandraCqlMapStateFactory(mapper, StateType.NON_TRANSACTIONAL, opts);
     }
 
     //////////////////////////////

--- a/src/main/java/com/hmsonline/trident/cql/CassandraCqlMapStateFactory.java
+++ b/src/main/java/com/hmsonline/trident/cql/CassandraCqlMapStateFactory.java
@@ -48,8 +48,7 @@ public class CassandraCqlMapStateFactory implements StateFactory {
     public State makeState(Map configuration, IMetricsContext metrics, int partitionIndex, int numPartitions) {
 
         if (clientFactory == null) {
-            String hosts = (String) configuration.get(CassandraCqlStateFactory.TRIDENT_CASSANDRA_CQL_HOSTS);
-            clientFactory = new CqlClientFactory(hosts, batchConsistencyLevel);
+            clientFactory = new MapConfiguredCqlClientFactory(configuration);
         }
 
         CassandraCqlMapState state = new CassandraCqlMapState(clientFactory.getSession(options.keyspace), mapper, options, configuration);
@@ -70,5 +69,4 @@ public class CassandraCqlMapStateFactory implements StateFactory {
 
         return new SnapshottableMap(mapState, new Values(options.globalKey));
     }
-
 }

--- a/src/main/java/com/hmsonline/trident/cql/CassandraCqlMapStateFactory.java
+++ b/src/main/java/com/hmsonline/trident/cql/CassandraCqlMapStateFactory.java
@@ -30,18 +30,15 @@ public class CassandraCqlMapStateFactory implements StateFactory {
     private CqlClientFactory clientFactory;
     private StateType stateType;
     private Options<?> options;
-    private ConsistencyLevel batchConsistencyLevel;
 
     @SuppressWarnings("rawtypes")
     private CqlRowMapper mapper;
 
     @SuppressWarnings({"rawtypes"})
-    public CassandraCqlMapStateFactory(CqlRowMapper mapper, StateType stateType, Options options, 
-            ConsistencyLevel batchConsistencyLevel) {
+    public CassandraCqlMapStateFactory(CqlRowMapper mapper, StateType stateType, Options options) {
         this.stateType = stateType;
         this.options = options;
         this.mapper = mapper;
-        this.batchConsistencyLevel = batchConsistencyLevel;
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/src/main/java/com/hmsonline/trident/cql/CassandraCqlStateFactory.java
+++ b/src/main/java/com/hmsonline/trident/cql/CassandraCqlStateFactory.java
@@ -16,13 +16,7 @@ import com.datastax.driver.core.ConsistencyLevel;
 public class CassandraCqlStateFactory implements StateFactory {
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(CassandraCqlStateFactory.class);
-    public static final String TRIDENT_CASSANDRA_CQL_HOSTS = "trident.cassandra.cql.hosts";
     public static final String TRIDENT_CASSANDRA_MAX_BATCH_SIZE = "trident.cassandra.maxbatchsize";
-    public static final String TRIDENT_CASSANDRA_COMPRESSION = "trident.cassandra.compression";
-    public static final String TRIDENT_CASSANDRA_CONSISTENCY = "trident.cassandra.consistency";
-    public static final String TRIDENT_CASSANDRA_SERIAL_CONSISTENCY = "trident.cassandra.serial.consistency";
-    public static final String TRIDENT_CASSANDRA_QUERY_TIMEOUT = "trident.cassandra.query.timeout";
-    public static final String TRIDENT_CASSANDRA_CLUSTER_NAME = "trident.cassandra.cluster.name";
 
     public static final int DEFAULT_MAX_BATCH_SIZE = 100;
     private static CqlClientFactory clientFactory;
@@ -36,17 +30,11 @@ public class CassandraCqlStateFactory implements StateFactory {
     public State makeState(Map configuration, IMetricsContext metrics, int partitionIndex, int numPartitions) {
         // worth synchronizing here?
         if (clientFactory == null) {
-            String hosts = (String) configuration.get(CassandraCqlStateFactory.TRIDENT_CASSANDRA_CQL_HOSTS);
-            String compressionLevel = (String) configuration.get(CassandraCqlStateFactory.TRIDENT_CASSANDRA_COMPRESSION);
-            if (compressionLevel == null){
-                // TODO: Can change to getOrDefault when we move to JDK 8
-                compressionLevel = ProtocolOptions.Compression.NONE.name();
-            }
-            clientFactory = new CqlClientFactory(hosts, null, batchConsistencyLevel, ConsistencyLevel.QUORUM, ProtocolOptions.Compression.valueOf(compressionLevel));
+            clientFactory = new MapConfiguredCqlClientFactory(configuration);
         }
         final String maxBatchSizeString = (String) configuration.get(CassandraCqlStateFactory.TRIDENT_CASSANDRA_MAX_BATCH_SIZE);
         final int maxBatchSize = (maxBatchSizeString == null) ? DEFAULT_MAX_BATCH_SIZE : Integer.parseInt((String) maxBatchSizeString);
         LOG.debug("Creating State for partition [{}] of [{}]", new Object[]{partitionIndex, numPartitions});
-        return new CassandraCqlState(CassandraCqlStateFactory.clientFactory, maxBatchSize, batchConsistencyLevel);
+        return new CassandraCqlState(clientFactory, maxBatchSize, batchConsistencyLevel);
     }
 }

--- a/src/main/java/com/hmsonline/trident/cql/ConstructorConfiguredCqlClientFactory.java
+++ b/src/main/java/com/hmsonline/trident/cql/ConstructorConfiguredCqlClientFactory.java
@@ -1,0 +1,76 @@
+package com.hmsonline.trident.cql;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.ProtocolOptions;
+import com.datastax.driver.core.QueryOptions;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+
+public class ConstructorConfiguredCqlClientFactory extends CqlClientFactory {
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(ConstructorConfiguredCqlClientFactory.class);
+    private String[] hosts;
+    private String clusterName = null;
+    private ConsistencyLevel clusterConsistencyLevel= null;
+    private ConsistencyLevel serialConsistencyLevel = null;
+
+    protected static Cluster cluster;
+    private final ProtocolOptions.Compression compression;
+
+    public ConstructorConfiguredCqlClientFactory(String hosts) {
+        this(hosts, null, ConsistencyLevel.QUORUM, QueryOptions.DEFAULT_SERIAL_CONSISTENCY_LEVEL, ProtocolOptions.Compression.NONE);
+    }
+
+    public ConstructorConfiguredCqlClientFactory(String hosts, ConsistencyLevel clusterConsistency) {
+        this(hosts, null, clusterConsistency, QueryOptions.DEFAULT_SERIAL_CONSISTENCY_LEVEL, ProtocolOptions.Compression.NONE);
+    }
+
+    public ConstructorConfiguredCqlClientFactory(String hosts, String clusterName, ConsistencyLevel clusterConsistency,
+                            ConsistencyLevel conditionalUpdateConsistency, ProtocolOptions.Compression compression) {
+        this.hosts = hosts.split(",");
+        this.clusterConsistencyLevel = clusterConsistency;
+        if (conditionalUpdateConsistency != null){
+            this.serialConsistencyLevel = conditionalUpdateConsistency;
+        }
+        if (clusterName != null) {
+            this.clusterName = clusterName;
+        }
+        this.compression = compression;
+    }
+    
+    public Cluster.Builder getClusterBuilder() {
+
+        final List<InetSocketAddress> sockets = new ArrayList<InetSocketAddress>();
+        for (String host : hosts) {
+            if(StringUtils.contains(host, ":")) {
+                String hostParts [] = StringUtils.split(host, ":");
+                sockets.add(new InetSocketAddress(hostParts[0], Integer.valueOf(hostParts[1])));
+                LOG.debug("Connecting to [" + host + "] with port [" + hostParts[1] + "]");
+            } else {
+                sockets.add(new InetSocketAddress(host, ProtocolOptions.DEFAULT_PORT));
+                LOG.debug("Connecting to [" + host + "] with port [" + ProtocolOptions.DEFAULT_PORT + "]");
+            }
+        }
+
+        Cluster.Builder builder = Cluster.builder().addContactPointsWithPorts(sockets).withCompression(compression);
+        QueryOptions queryOptions = new QueryOptions();
+        queryOptions.setConsistencyLevel(clusterConsistencyLevel);
+        queryOptions.setSerialConsistencyLevel(serialConsistencyLevel);
+        builder = builder.withQueryOptions(queryOptions);
+
+        if (StringUtils.isNotEmpty(clusterName)) {
+            builder = builder.withClusterName(clusterName);
+        }
+
+        return builder;
+
+    }
+}

--- a/src/main/java/com/hmsonline/trident/cql/CqlClientFactory.java
+++ b/src/main/java/com/hmsonline/trident/cql/CqlClientFactory.java
@@ -1,59 +1,23 @@
 package com.hmsonline.trident.cql;
 
-import java.io.Serializable;
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.lang.StringUtils;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.ConsistencyLevel;
-import com.datastax.driver.core.ProtocolOptions;
-import com.datastax.driver.core.QueryOptions;
-import com.datastax.driver.core.Session;
-import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
-/**
- * @author boneill
- */
-public class CqlClientFactory implements Serializable {
-    private static final long serialVersionUID = 1L;
+public abstract class CqlClientFactory implements Serializable {
+
+    private static final long serialVersionUID = 2L;
     private static final Logger LOG = LoggerFactory.getLogger(CqlClientFactory.class);
     private Map<String, Session> sessions = new HashMap<String, Session>();
     private Session defaultSession = null;
-    private String[] hosts;
-    private String clusterName = null;
-    private ConsistencyLevel clusterConsistencyLevel= null;
-    private ConsistencyLevel serialConsistencyLevel = null;
+    private Cluster cluster = null;
 
-    protected static Cluster cluster;
-    private final ProtocolOptions.Compression compression;
-
-    public CqlClientFactory(String hosts) {
-        this(hosts, null, ConsistencyLevel.QUORUM, QueryOptions.DEFAULT_SERIAL_CONSISTENCY_LEVEL, ProtocolOptions.Compression.NONE);
-    }
-
-    public CqlClientFactory(String hosts, ConsistencyLevel clusterConsistency) {
-        this(hosts, null, clusterConsistency, QueryOptions.DEFAULT_SERIAL_CONSISTENCY_LEVEL, ProtocolOptions.Compression.NONE);
-    }
-
-    public CqlClientFactory(String hosts, String clusterName, ConsistencyLevel clusterConsistency,
-                            ConsistencyLevel conditionalUpdateConsistency, ProtocolOptions.Compression compression) {
-        this.hosts = hosts.split(",");
-        this.clusterConsistencyLevel = clusterConsistency;
-        if (conditionalUpdateConsistency != null){
-            this.serialConsistencyLevel = conditionalUpdateConsistency;
-        }
-        if (clusterName != null) {
-            this.clusterName = clusterName;
-        }
-        this.compression = compression;
-    }
+    abstract Cluster.Builder getClusterBuilder();
 
     public synchronized Session getSession(String keyspace) {
         Session session = sessions.get(keyspace);
@@ -66,48 +30,25 @@ public class CqlClientFactory implements Serializable {
     }
 
     public synchronized Session getSession() {
-        if (defaultSession == null)
+        if (defaultSession == null) {
             defaultSession = getCluster().connect();
+        }
         return defaultSession;
     }
-    
+
     public Cluster getCluster() {
         if (cluster == null || cluster.isClosed()) {
             if (cluster != null && cluster.isClosed()){
                 LOG.warn("Cluster closed, reconstructing cluster for [{}]", cluster.getClusterName());
             }
-            try {
-                List<InetSocketAddress> sockets = new ArrayList<InetSocketAddress>();
-                for (String host : hosts) {
-                    if(StringUtils.contains(host, ":")) {
-                        String hostParts [] = StringUtils.split(host, ":");
-                        sockets.add(new InetSocketAddress(hostParts[0], Integer.valueOf(hostParts[1])));
-                        LOG.debug("Connecting to [" + host + "] with port [" + hostParts[1] + "]");
-                    } else {
-                        sockets.add(new InetSocketAddress(host, ProtocolOptions.DEFAULT_PORT));
-                        LOG.debug("Connecting to [" + host + "] with port [" + ProtocolOptions.DEFAULT_PORT + "]");
-                    }
-                }
 
-                Cluster.Builder builder = Cluster.builder().addContactPointsWithPorts(sockets).withCompression(compression);
-                QueryOptions queryOptions = new QueryOptions();
-                queryOptions.setConsistencyLevel(clusterConsistencyLevel);
-                queryOptions.setSerialConsistencyLevel(serialConsistencyLevel);
-                builder = builder.withQueryOptions(queryOptions);
+            cluster = getClusterBuilder().build();
 
-                if (StringUtils.isNotEmpty(clusterName)) {
-                    builder = builder.withClusterName(clusterName);
-                }
-
-                cluster = builder.build();
-                if (cluster == null) {
-                    throw new RuntimeException("Critical error: cluster is null after "
-                            + "attempting to build with contact points (hosts) " + hosts);
-                }
-            } catch (NoHostAvailableException e) {
-                throw new RuntimeException(e);
+            if (cluster == null) {
+                throw new RuntimeException("Critical error: cluster is null after building.");
             }
         }
+
         return cluster;
     }
 }

--- a/src/main/java/com/hmsonline/trident/cql/MapConfiguredCqlClientFactory.java
+++ b/src/main/java/com/hmsonline/trident/cql/MapConfiguredCqlClientFactory.java
@@ -1,0 +1,127 @@
+package com.hmsonline.trident.cql;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.ProtocolOptions;
+import com.datastax.driver.core.QueryOptions;
+import com.datastax.driver.core.SocketOptions;
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class MapConfiguredCqlClientFactory extends CqlClientFactory {
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(MapConfiguredCqlClientFactory.class);
+
+    public static final String TRIDENT_CASSANDRA_CQL_HOSTS = "trident.cassandra.cql.hosts";
+    public static final String TRIDENT_CASSANDRA_COMPRESSION = "trident.cassandra.compression";
+    public static final String TRIDENT_CASSANDRA_CONNECT_TIMEOUT = "trident.cassandra.connect.timeout";
+    public static final String TRIDENT_CASSANDRA_READ_TIMEOUT = "trident.cassandra.read.timeout";
+    public static final String TRIDENT_CASSANDRA_CLUSTER_NAME = "trident.cassandra.cluster.name";
+    public static final String TRIDENT_CASSANDRA_LOCAL_DATA_CENTER_NAME = "trident.cassandra.local.data.center.name";
+    public static final String TRIDENT_CASSANDRA_CONSISTENCY = "trident.cassandra.consistency";
+    public static final String TRIDENT_CASSANDRA_SERIAL_CONSISTENCY = "trident.cassandra.serial.consistency";
+
+    final Map configuration;
+
+    Cluster.Builder builder;
+
+    public MapConfiguredCqlClientFactory(final Map configuration) {
+        this.builder = Cluster.builder();
+        this.configuration = configuration;
+    }
+
+    private void configureHosts() {
+        final String hostConfiguration = (String) configuration.get(TRIDENT_CASSANDRA_CQL_HOSTS);
+        final String[] hosts = hostConfiguration.split(",");
+        final List<InetSocketAddress> sockets = new ArrayList<InetSocketAddress>();
+        for (final String host : hosts) {
+            if(StringUtils.contains(host, ":")) {
+                final String hostParts [] = StringUtils.split(host, ":");
+                sockets.add(new InetSocketAddress(hostParts[0], Integer.valueOf(hostParts[1])));
+                LOG.debug("Configuring [" + host + "] with port [" + hostParts[1] + "]");
+            } else {
+                sockets.add(new InetSocketAddress(host, ProtocolOptions.DEFAULT_PORT));
+                LOG.debug("Configuring [" + host + "] with port [" + ProtocolOptions.DEFAULT_PORT + "]");
+            }
+        }
+        builder = builder.addContactPointsWithPorts(sockets);
+    }
+
+    private void configureSocketOpts() {
+        final String readTimeoutConfiguration = (String) configuration.get(TRIDENT_CASSANDRA_READ_TIMEOUT);
+        final String connectTimeoutConfiguration = (String) configuration.get(TRIDENT_CASSANDRA_CONNECT_TIMEOUT);
+        final SocketOptions socketOptions = builder.getConfiguration().getSocketOptions();
+
+        if (StringUtils.isNotEmpty(readTimeoutConfiguration)) {
+            socketOptions.setReadTimeoutMillis(Integer.parseInt(readTimeoutConfiguration));
+        }
+
+        if (StringUtils.isNotEmpty(connectTimeoutConfiguration)) {
+            socketOptions.setConnectTimeoutMillis(Integer.parseInt(connectTimeoutConfiguration));
+        }
+
+        builder = builder.withSocketOptions(socketOptions);
+    }
+
+    private void configureQueryOptions() {
+
+        final String consistencyConfiguration = (String) configuration.get(TRIDENT_CASSANDRA_CONSISTENCY);
+        final String serialConsistencyConfiguration = (String) configuration.get(TRIDENT_CASSANDRA_SERIAL_CONSISTENCY);
+        final QueryOptions queryOptions = builder.getConfiguration().getQueryOptions();
+
+        if (StringUtils.isNotEmpty(consistencyConfiguration)) {
+            queryOptions.setConsistencyLevel(ConsistencyLevel.valueOf(consistencyConfiguration));
+        }
+
+        if (StringUtils.isNotEmpty(serialConsistencyConfiguration)) {
+            queryOptions.setSerialConsistencyLevel(ConsistencyLevel.valueOf(serialConsistencyConfiguration));
+        }
+
+        builder = builder.withQueryOptions(queryOptions);
+
+    }
+
+    private void configureCompression() {
+        final String compressionConfiguration = (String) configuration.get(TRIDENT_CASSANDRA_COMPRESSION);
+        if (StringUtils.isNotEmpty(compressionConfiguration)) {
+            builder = builder.withCompression(ProtocolOptions.Compression.valueOf(compressionConfiguration));
+        }
+    }
+
+    private void configureOther() {
+        final String nameConfiguration = (String) configuration.get(TRIDENT_CASSANDRA_CLUSTER_NAME);
+        if (StringUtils.isNotEmpty(nameConfiguration)) {
+            builder = builder.withClusterName(nameConfiguration);
+        }
+    }
+
+    private void configureLoadBalancingPolicy() {
+        final String dataCenterNameConfiguration = (String) configuration.get(TRIDENT_CASSANDRA_LOCAL_DATA_CENTER_NAME);
+        if (StringUtils.isNotEmpty(dataCenterNameConfiguration)) {
+            final LoadBalancingPolicy loadBalancingPolicy = new DCAwareRoundRobinPolicy(dataCenterNameConfiguration);
+            builder = builder.withLoadBalancingPolicy(loadBalancingPolicy);
+        }
+    }
+
+    public void configure() {
+        configureHosts();
+        configureSocketOpts();
+        configureQueryOptions();
+        configureCompression();
+        configureLoadBalancingPolicy();
+        configureOther();
+    }
+
+    public Cluster.Builder getClusterBuilder() {
+        configure();
+        return builder;
+    }
+}

--- a/src/main/java/com/hmsonline/trident/cql/incremental/CassandraCqlIncrementalStateFactory.java
+++ b/src/main/java/com/hmsonline/trident/cql/incremental/CassandraCqlIncrementalStateFactory.java
@@ -2,10 +2,9 @@ package com.hmsonline.trident.cql.incremental;
 
 import backtype.storm.task.IMetricsContext;
 
-import com.datastax.driver.core.ConsistencyLevel;
-import com.hmsonline.trident.cql.CassandraCqlStateFactory;
 import com.hmsonline.trident.cql.CqlClientFactory;
 
+import com.hmsonline.trident.cql.MapConfiguredCqlClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,14 +19,11 @@ import java.util.Map;
 public class CassandraCqlIncrementalStateFactory<K, V> implements StateFactory {
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(CassandraCqlIncrementalStateFactory.class);
-    public static String TRIDENT_CASSANDRA_CQL_HOSTS = "trident.cassandra.cql.hosts";
     private static CqlClientFactory clientFactory;
     private CombinerAggregator<V> aggregator;
     private CqlIncrementMapper<K, V> mapper;
-    private ConsistencyLevel batchConsistencyLevel;
 
-    public CassandraCqlIncrementalStateFactory(CombinerAggregator<V> aggregator, CqlIncrementMapper<K, V> mapper,
-            ConsistencyLevel batchConsistencyLevel) {
+    public CassandraCqlIncrementalStateFactory(CombinerAggregator<V> aggregator, CqlIncrementMapper<K, V> mapper) {
         this.aggregator = aggregator;
         this.mapper = mapper;
     }
@@ -36,10 +32,9 @@ public class CassandraCqlIncrementalStateFactory<K, V> implements StateFactory {
     public State makeState(Map configuration, IMetricsContext metrics, int partitionIndex, int numPartitions) {
         // worth synchronizing here?
         if (clientFactory == null) {
-            String hosts = (String) configuration.get(CassandraCqlStateFactory.TRIDENT_CASSANDRA_CQL_HOSTS);
-            clientFactory = new CqlClientFactory(hosts, batchConsistencyLevel);
+            clientFactory = new MapConfiguredCqlClientFactory(configuration);
         }
         LOG.debug("Creating State for partition [{}] of [{}]", new Object[]{partitionIndex, numPartitions});
-        return new CassandraCqlIncrementalState<K, V>(CassandraCqlIncrementalStateFactory.clientFactory, aggregator, mapper, partitionIndex);
+        return new CassandraCqlIncrementalState<K, V>(clientFactory, aggregator, mapper, partitionIndex);
     }
 }

--- a/src/test/java/com/hmsonline/trident/cql/ConditionalUpdateTest.java
+++ b/src/test/java/com/hmsonline/trident/cql/ConditionalUpdateTest.java
@@ -8,10 +8,6 @@ import static com.hmsonline.trident.cql.incremental.example.SalesAnalyticsMapper
 import static com.hmsonline.trident.cql.incremental.example.SalesAnalyticsMapper.KEY_NAME;
 import static com.hmsonline.trident.cql.incremental.example.SalesAnalyticsMapper.TABLE_NAME;
 import static com.hmsonline.trident.cql.incremental.example.SalesAnalyticsMapper.VALUE_NAME;
-import static org.junit.Assert.assertEquals;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -20,10 +16,6 @@ import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.Row;
-import com.datastax.driver.core.Statement;
-import com.datastax.driver.core.querybuilder.Select;
 import com.datastax.driver.core.querybuilder.Update;
 
 /**
@@ -31,32 +23,12 @@ import com.datastax.driver.core.querybuilder.Update;
  */
 @Ignore
 @RunWith(JUnit4.class)
-public class ConditionalUpdateTest {
+public class ConditionalUpdateTest extends StateTest {
     private static final Logger LOG = LoggerFactory.getLogger(ConditionalUpdateTest.class);
-    public CqlClientFactory clientFactory;
-    public Map<String, String> configuration = new HashMap<String, String>();
     public String APPLIED_COLUMN = "[applied]";
 
     public ConditionalUpdateTest() {
-        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_CQL_HOSTS, "localhost");
-        clientFactory = new MapConfiguredCqlClientFactory(configuration);
-    }
-
-    public void assertValue(String k, Integer expectedValue) {
-        Select selectStatement = select().column("v").from(KEYSPACE_NAME, TABLE_NAME);
-        selectStatement.where(eq(KEY_NAME, k));
-        ResultSet results = clientFactory.getSession().execute(selectStatement);
-        Integer actualValue = results.one().getInt(VALUE_NAME);
-        assertEquals(expectedValue, actualValue);
-    }
-
-    public void executeAndAssert(Statement statement, String k, Integer expectedValue) {
-        LOG.debug("EXECUTING [{}]", statement.toString());
-        ResultSet results = clientFactory.getSession().execute(statement);
-        Row row = results.one();
-        if (row != null)
-            LOG.debug("APPLIED?[{}]", row.getBool("[applied]"));
-        this.assertValue(k, expectedValue);
+        super();
     }
 
     @Test

--- a/src/test/java/com/hmsonline/trident/cql/ConditionalUpdateTest.java
+++ b/src/test/java/com/hmsonline/trident/cql/ConditionalUpdateTest.java
@@ -20,7 +20,6 @@ import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Statement;
@@ -35,11 +34,12 @@ import com.datastax.driver.core.querybuilder.Update;
 public class ConditionalUpdateTest {
     private static final Logger LOG = LoggerFactory.getLogger(ConditionalUpdateTest.class);
     public CqlClientFactory clientFactory;
-    public Map<String, String> configuration;
+    public Map<String, String> configuration = new HashMap<String, String>();
     public String APPLIED_COLUMN = "[applied]";
 
     public ConditionalUpdateTest() {
-        clientFactory = new CqlClientFactory("localhost", ConsistencyLevel.QUORUM);
+        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_CQL_HOSTS, "localhost");
+        clientFactory = new MapConfiguredCqlClientFactory(configuration);
     }
 
     public void assertValue(String k, Integer expectedValue) {

--- a/src/test/java/com/hmsonline/trident/cql/ConstructorConfiguredCqlClientFactoryTest.java
+++ b/src/test/java/com/hmsonline/trident/cql/ConstructorConfiguredCqlClientFactoryTest.java
@@ -1,0 +1,37 @@
+package com.hmsonline.trident.cql;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.ProtocolOptions;
+import junit.framework.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.net.InetSocketAddress;
+
+import static org.junit.Assert.*;
+
+@RunWith(JUnit4.class)
+public class ConstructorConfiguredCqlClientFactoryTest extends CqlClientFactoryTest {
+
+    @Test
+    public void testGetCluster() {
+        final CqlClientFactory factory =
+                new ConstructorConfiguredCqlClientFactory(HOSTS,
+                                                          CLUSTER_NAME,
+                                                          DEFAULT_CONSISTENCY_LEVEL,
+                                                          DEFAULT_SERIAL_CONSISTENCY_LEVEL,
+                                                          COMPRESSION);
+
+        final Cluster.Builder clusterBuilder = factory.getClusterBuilder();
+        Assert.assertEquals(CLUSTER_NAME, clusterBuilder.getClusterName());
+        final InetSocketAddress first = clusterBuilder.getContactPoints().get(0);
+        final InetSocketAddress second = clusterBuilder.getContactPoints().get(1);
+        Assert.assertEquals("localhost", first.getHostName());
+        Assert.assertEquals(9042, first.getPort());
+        Assert.assertEquals("remotehost", second.getHostName());
+        Assert.assertEquals(1234, second.getPort());
+    }
+
+}

--- a/src/test/java/com/hmsonline/trident/cql/CqlClientFactoryTest.java
+++ b/src/test/java/com/hmsonline/trident/cql/CqlClientFactoryTest.java
@@ -2,21 +2,17 @@ package com.hmsonline.trident.cql;
 
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.ProtocolOptions;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-
-@RunWith(JUnit4.class)
 public class CqlClientFactoryTest {
-	private static final Logger LOG = LoggerFactory.getLogger(CqlClientFactoryTest.class);
-	public CqlClientFactory clientFactory;
 
-	@Test
-	public void testCompressionConf() throws Exception {
-		clientFactory = new CqlClientFactory("", null, null, ConsistencyLevel.ANY, ProtocolOptions.Compression.valueOf("LZ4"));
-		clientFactory = new CqlClientFactory("", null, null, ConsistencyLevel.ANY, ProtocolOptions.Compression.valueOf("NONE"));
-	}
+    public static final String HOSTS = "localhost,remotehost:1234";
+    public static final String CLUSTER_NAME = "Test Cluster";
+    public static final ConsistencyLevel DEFAULT_CONSISTENCY_LEVEL = ConsistencyLevel.LOCAL_QUORUM;
+    public static final ConsistencyLevel DEFAULT_SERIAL_CONSISTENCY_LEVEL = ConsistencyLevel.SERIAL;
+    public static final ProtocolOptions.Compression COMPRESSION = ProtocolOptions.Compression.LZ4;
+    public static final String READ_TIMEOUT = "10000";
+    public static final String CONNECT_TIMEOUT = "2000";
+    public static final String DATA_CENTER_NAME = "philly";
+
+
 }

--- a/src/test/java/com/hmsonline/trident/cql/IncrementalStateTest.java
+++ b/src/test/java/com/hmsonline/trident/cql/IncrementalStateTest.java
@@ -2,7 +2,6 @@ package com.hmsonline.trident.cql;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.delete;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
 import static com.hmsonline.trident.cql.incremental.example.SalesAnalyticsMapper.KEYSPACE_NAME;
 import static com.hmsonline.trident.cql.incremental.example.SalesAnalyticsMapper.KEY_NAME;
 import static com.hmsonline.trident.cql.incremental.example.SalesAnalyticsMapper.TABLE_NAME;
@@ -11,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.datastax.driver.core.querybuilder.Insert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,7 +19,6 @@ import storm.trident.operation.builtin.Sum;
 import storm.trident.testing.MockTridentTuple;
 import storm.trident.tuple.TridentTuple;
 
-import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.querybuilder.Delete;
 import com.hmsonline.trident.cql.incremental.CassandraCqlIncrementalState;
 import com.hmsonline.trident.cql.incremental.CassandraCqlIncrementalStateFactory;
@@ -33,7 +30,7 @@ import com.hmsonline.trident.cql.incremental.example.SalesAnalyticsMapper;
  */
 @Ignore
 @RunWith(JUnit4.class)
-public class IncrementalStateTest extends ConditionalUpdateTest {
+public class IncrementalStateTest extends StateTest {
     private CassandraCqlIncrementalStateFactory<String, Number> stateFactory;
     private CassandraCqlIncrementalStateUpdater<String, Number> stateUpdater;
     private static List<String> FIELDS = Arrays.asList("price", "state", "product");
@@ -62,17 +59,17 @@ public class IncrementalStateTest extends ConditionalUpdateTest {
 
         //Insert insertStament = insertInto(KEYSPACE_NAME, TABLE_NAME).value("k","MD").value("v", 99);
         //clientFactory.getSession().execute(insertStament);
-        this.incrementState(state);
+        incrementState(state);
         state.commit(Long.MAX_VALUE);
-        this.assertValue("MD", 100);
+        assertValue("MD", 100);
 
         // Let's create two state objects, to simulate
         // multi-threaded/distributed operations.
         CassandraCqlIncrementalState<String, Number> state1 = (CassandraCqlIncrementalState<String, Number>) stateFactory.makeState(
                 configuration, null, 55, 122);
-        this.incrementState(state1);
+        incrementState(state1);
         state.commit(Long.MAX_VALUE);
-        this.assertValue("MD", 200);
+        assertValue("MD", 200);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/hmsonline/trident/cql/IncrementalStateTest.java
+++ b/src/test/java/com/hmsonline/trident/cql/IncrementalStateTest.java
@@ -2,6 +2,7 @@ package com.hmsonline.trident.cql;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.delete;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
 import static com.hmsonline.trident.cql.incremental.example.SalesAnalyticsMapper.KEYSPACE_NAME;
 import static com.hmsonline.trident.cql.incremental.example.SalesAnalyticsMapper.KEY_NAME;
 import static com.hmsonline.trident.cql.incremental.example.SalesAnalyticsMapper.TABLE_NAME;
@@ -10,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.datastax.driver.core.querybuilder.Insert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,8 +39,9 @@ public class IncrementalStateTest extends ConditionalUpdateTest {
     private static List<String> FIELDS = Arrays.asList("price", "state", "product");
 
     public IncrementalStateTest() {
+        super();
         SalesAnalyticsMapper mapper = new SalesAnalyticsMapper();
-        stateFactory = new CassandraCqlIncrementalStateFactory<String, Number>(new Sum(), mapper, ConsistencyLevel.QUORUM);
+        stateFactory = new CassandraCqlIncrementalStateFactory<String, Number>(new Sum(), mapper);
         stateUpdater = new CassandraCqlIncrementalStateUpdater<String, Number>();
     }
 
@@ -56,6 +59,9 @@ public class IncrementalStateTest extends ConditionalUpdateTest {
         // Let's get some initial state in the database
         CassandraCqlIncrementalState<String, Number> state = (CassandraCqlIncrementalState<String, Number>) stateFactory.makeState(
                 configuration, null, 5, 50);
+
+        //Insert insertStament = insertInto(KEYSPACE_NAME, TABLE_NAME).value("k","MD").value("v", 99);
+        //clientFactory.getSession().execute(insertStament);
         this.incrementState(state);
         state.commit(Long.MAX_VALUE);
         this.assertValue("MD", 100);

--- a/src/test/java/com/hmsonline/trident/cql/MapConfiguredCqlClientFactoryTest.java
+++ b/src/test/java/com/hmsonline/trident/cql/MapConfiguredCqlClientFactoryTest.java
@@ -1,0 +1,57 @@
+package com.hmsonline.trident.cql;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ProtocolOptions;
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import junit.framework.Assert;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class MapConfiguredCqlClientFactoryTest extends CqlClientFactoryTest {
+
+    @Test
+    public void testGetClusterBuilder() throws Exception {
+        final Map<String, String> configuration = new HashMap<String,String>();
+        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_CQL_HOSTS, HOSTS);
+        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_CLUSTER_NAME, CLUSTER_NAME);
+        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_READ_TIMEOUT, READ_TIMEOUT);
+        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_CONNECT_TIMEOUT, CONNECT_TIMEOUT);
+        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_LOCAL_DATA_CENTER_NAME, DATA_CENTER_NAME);
+        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_CONSISTENCY, DEFAULT_CONSISTENCY_LEVEL.name());
+        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_SERIAL_CONSISTENCY, DEFAULT_SERIAL_CONSISTENCY_LEVEL.name());
+
+        final CqlClientFactory factory =
+                new MapConfiguredCqlClientFactory(configuration);
+
+        final Cluster.Builder clusterBuilder = factory.getClusterBuilder();
+        Assert.assertEquals(CLUSTER_NAME, clusterBuilder.getClusterName());
+        final InetSocketAddress first = clusterBuilder.getContactPoints().get(0);
+        final InetSocketAddress second = clusterBuilder.getContactPoints().get(1);
+        Assert.assertEquals("localhost", first.getHostName());
+        Assert.assertEquals(9042, first.getPort());
+        Assert.assertEquals("remotehost", second.getHostName());
+        Assert.assertEquals(1234, second.getPort());
+        Assert.assertEquals(Integer.parseInt(CONNECT_TIMEOUT), clusterBuilder.getConfiguration().getSocketOptions().getConnectTimeoutMillis());
+        Assert.assertEquals(Integer.parseInt(READ_TIMEOUT), clusterBuilder.getConfiguration().getSocketOptions().getReadTimeoutMillis());
+        Assert.assertEquals(DEFAULT_CONSISTENCY_LEVEL, clusterBuilder.getConfiguration().getQueryOptions().getConsistencyLevel());
+        Assert.assertEquals(DEFAULT_SERIAL_CONSISTENCY_LEVEL, clusterBuilder.getConfiguration().getQueryOptions().getSerialConsistencyLevel());
+        Assert.assertEquals(ProtocolOptions.Compression.NONE, clusterBuilder.getConfiguration().getProtocolOptions().getCompression());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCompression() {
+        final Map<String, String> configuration = new HashMap<String,String>();
+        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_CQL_HOSTS, HOSTS);
+        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_COMPRESSION, COMPRESSION.name());
+        final CqlClientFactory factory =
+                new MapConfiguredCqlClientFactory(configuration);
+        factory.getClusterBuilder().getConfiguration().getProtocolOptions().getCompression();
+        // We're testing for the exception here since we don't have LZ4 on our classpath.
+        // Assert.assertEquals(COMPRESSION, clusterBuilder.getConfiguration().getProtocolOptions().getCompression());
+    }
+}

--- a/src/test/java/com/hmsonline/trident/cql/StateTest.java
+++ b/src/test/java/com/hmsonline/trident/cql/StateTest.java
@@ -1,0 +1,46 @@
+package com.hmsonline.trident.cql;
+
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.querybuilder.Select;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static com.hmsonline.trident.cql.incremental.example.SalesAnalyticsMapper.*;
+import static org.junit.Assert.assertEquals;
+
+public class StateTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StateTest.class);
+
+    public CqlClientFactory clientFactory;
+    public Map<String, String> configuration = new HashMap<String, String>();
+
+    public StateTest() {
+        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_CQL_HOSTS, "localhost");
+        clientFactory = new MapConfiguredCqlClientFactory(configuration);
+    }
+
+    public void assertValue(String k, Integer expectedValue) {
+        Select selectStatement = select().column("v").from(KEYSPACE_NAME, TABLE_NAME);
+        selectStatement.where(eq(KEY_NAME, k));
+        ResultSet results = clientFactory.getSession().execute(selectStatement);
+        Integer actualValue = results.one().getInt(VALUE_NAME);
+        assertEquals(expectedValue, actualValue);
+    }
+
+    public void executeAndAssert(Statement statement, String k, Integer expectedValue) {
+        LOG.debug("EXECUTING [{}]", statement.toString());
+        ResultSet results = clientFactory.getSession().execute(statement);
+        Row row = results.one();
+        if (row != null)
+            LOG.debug("APPLIED?[{}]", row.getBool("[applied]"));
+        assertValue(k, expectedValue);
+    }
+}

--- a/src/test/java/com/hmsonline/trident/cql/example/ExampleTopology.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/ExampleTopology.java
@@ -1,5 +1,6 @@
 package com.hmsonline.trident.cql.example;
 
+import com.hmsonline.trident.cql.MapConfiguredCqlClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +30,7 @@ public class ExampleTopology {
 
     public static void main(String[] args) throws Exception {
         final Config configuration = new Config();
-        configuration.put(CassandraCqlStateFactory.TRIDENT_CASSANDRA_CQL_HOSTS, "localhost");
+        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_CQL_HOSTS, "localhost");
         final LocalCluster cluster = new LocalCluster();
         LOG.info("Submitting topology.");
         cluster.submitTopology("cqlexample", configuration, buildTopology());

--- a/src/test/java/com/hmsonline/trident/cql/example/wordcount/WordCountTopology.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/wordcount/WordCountTopology.java
@@ -8,6 +8,7 @@ import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Values;
 import com.hmsonline.trident.cql.CassandraCqlMapState;
 import com.hmsonline.trident.cql.CassandraCqlStateFactory;
+import com.hmsonline.trident.cql.MapConfiguredCqlClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import storm.trident.TridentState;
@@ -91,7 +92,7 @@ public class WordCountTopology {
 
     public static void main(String[] args) throws Exception {
         final Config configuration = new Config();
-        configuration.put(CassandraCqlStateFactory.TRIDENT_CASSANDRA_CQL_HOSTS, "localhost");
+        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_CQL_HOSTS, "localhost");
         final LocalCluster cluster = new LocalCluster();
         LocalDRPC client = new LocalDRPC();
 

--- a/src/test/java/com/hmsonline/trident/cql/incremental/example/SalesAnalyticsMapper.java
+++ b/src/test/java/com/hmsonline/trident/cql/incremental/example/SalesAnalyticsMapper.java
@@ -7,6 +7,7 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
 import java.io.Serializable;
 import java.util.List;
 
+import com.datastax.driver.core.ConsistencyLevel;
 import storm.trident.tuple.TridentTuple;
 
 import com.datastax.driver.core.Row;
@@ -47,7 +48,12 @@ public class SalesAnalyticsMapper implements CqlIncrementMapper<String, Number>,
 
     @Override
     public SalesState currentState(String key, List<Row> rows) {
-        return new SalesState(rows.get(0).getInt(VALUE_NAME),rows.get(0).getString("partitions"));
+        if (rows.size() == 0) {
+            return new SalesState(null, null);
+        } else {
+            return new SalesState(rows.get(0).getInt(VALUE_NAME), "0");
+            // return new SalesState(rows.get(0).getInt(VALUE_NAME), rows.get(0).getString("partitions"));
+        }
     }
 
     @Override

--- a/src/test/java/com/hmsonline/trident/cql/incremental/example/SalesAnalyticsMapper.java
+++ b/src/test/java/com/hmsonline/trident/cql/incremental/example/SalesAnalyticsMapper.java
@@ -31,7 +31,7 @@ public class SalesAnalyticsMapper implements CqlIncrementMapper<String, Number>,
 
     @Override
     public Statement read(String key) {
-        Select statement = select().column("v").from(KEYSPACE_NAME, TABLE_NAME);
+        Select statement = select().column(VALUE_NAME).from(KEYSPACE_NAME, TABLE_NAME);
         statement.where(eq(KEY_NAME, key));
         return statement;
     }
@@ -51,8 +51,7 @@ public class SalesAnalyticsMapper implements CqlIncrementMapper<String, Number>,
         if (rows.size() == 0) {
             return new SalesState(null, null);
         } else {
-            return new SalesState(rows.get(0).getInt(VALUE_NAME), "0");
-            // return new SalesState(rows.get(0).getInt(VALUE_NAME), rows.get(0).getString("partitions"));
+            return new SalesState(rows.get(0).getInt(VALUE_NAME), "");
         }
     }
 

--- a/src/test/java/com/hmsonline/trident/cql/incremental/example/SalesAnalyticsTopology.java
+++ b/src/test/java/com/hmsonline/trident/cql/incremental/example/SalesAnalyticsTopology.java
@@ -7,6 +7,7 @@ import backtype.storm.tuple.Fields;
 
 import com.datastax.driver.core.ConsistencyLevel;
 import com.hmsonline.trident.cql.CassandraCqlStateFactory;
+import com.hmsonline.trident.cql.MapConfiguredCqlClientFactory;
 import com.hmsonline.trident.cql.incremental.CassandraCqlIncrementalStateFactory;
 import com.hmsonline.trident.cql.incremental.CassandraCqlIncrementalStateUpdater;
 
@@ -27,7 +28,7 @@ public class SalesAnalyticsTopology {
         Stream inputStream = topology.newStream("sales", spout);
         SalesAnalyticsMapper mapper = new SalesAnalyticsMapper();
         inputStream.partitionPersist(
-                new CassandraCqlIncrementalStateFactory<String, Number>(new Sum(), mapper, ConsistencyLevel.QUORUM),
+                new CassandraCqlIncrementalStateFactory<String, Number>(new Sum(), mapper),
                 new Fields("price", "state", "product"),
                 new CassandraCqlIncrementalStateUpdater<String, Number>());
         return topology.build();
@@ -35,7 +36,7 @@ public class SalesAnalyticsTopology {
 
     public static void main(String[] args) throws Exception {
         final Config configuration = new Config();
-        configuration.put(CassandraCqlStateFactory.TRIDENT_CASSANDRA_CQL_HOSTS, "localhost");
+        configuration.put(MapConfiguredCqlClientFactory.TRIDENT_CASSANDRA_CQL_HOSTS, "localhost");
         final LocalCluster cluster = new LocalCluster();
         LOG.info("Submitting topology.");
         cluster.submitTopology("cqlexample", configuration, buildTopology());

--- a/src/test/java/com/hmsonline/trident/cql/incremental/example/SalesState.java
+++ b/src/test/java/com/hmsonline/trident/cql/incremental/example/SalesState.java
@@ -7,7 +7,7 @@ public class SalesState implements PersistedState<Number> {
     String partitionsKey;
     public SalesState(Number value,String partitionsKey){
         this.value = value;
-        this.partitionsKey=partitionsKey;
+        this.partitionsKey = partitionsKey;
     }
     
     @Override

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -12,3 +12,5 @@ log4j.logger.org.apache=WARN
 log4j.logger.com.griddelta=DEBUG
 log4j.logger.com.netflix=WARN
 
+log4j.logger.backtype.storm.daemon.nimbus=INFO
+


### PR DESCRIPTION
You can now set additional options in the configuration map.

    public static final String TRIDENT_CASSANDRA_CQL_HOSTS = "trident.cassandra.cql.hosts";
    public static final String TRIDENT_CASSANDRA_COMPRESSION = "trident.cassandra.compression";
    public static final String TRIDENT_CASSANDRA_CONNECT_TIMEOUT = "trident.cassandra.connect.timeout";
    public static final String TRIDENT_CASSANDRA_READ_TIMEOUT = "trident.cassandra.read.timeout";
    public static final String TRIDENT_CASSANDRA_CLUSTER_NAME = "trident.cassandra.cluster.name";
    public static final String TRIDENT_CASSANDRA_LOCAL_DATA_CENTER_NAME = "trident.cassandra.local.data.center.name";
    public static final String TRIDENT_CASSANDRA_CONSISTENCY = "trident.cassandra.consistency";
    public static final String TRIDENT_CASSANDRA_SERIAL_CONSISTENCY = "trident.cassandra.serial.consistency";

Also, CqlClientFactory is now abstract which allows us to configure them in different ways (ie, spring) when reusing code in a non-storm context.