### PR TITLE
Bump cassandra-driver-core dependency to 2.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>com.datastax.cassandra</groupId>
 			<artifactId>cassandra-driver-core</artifactId>
-			<version>2.1.4</version>
+			<version>2.1.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.cassandraunit</groupId>


### PR DESCRIPTION
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 23.373 s
[INFO] Finished at: 2015-05-28T14:40:24-04:00
[INFO] Final Memory: 25M/193M
[INFO] ------------------------------------------------------------------------
```