### PR TITLE
Changed cast strategy in registerMetrics to avoid ClassCastException

### DIFF
--- a/src/main/java/com/hmsonline/trident/cql/CassandraCqlMapState.java
+++ b/src/main/java/com/hmsonline/trident/cql/CassandraCqlMapState.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import clojure.lang.RT;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -219,7 +220,7 @@ public class CassandraCqlMapState<T> implements IBackingMap<T> {
 
     @SuppressWarnings("rawtypes")
     public void registerMetrics(Map conf, IMetricsContext context, String mapStateMetricName) {
-        int bucketSize = (Integer) (conf.get(Config.TOPOLOGY_BUILTIN_METRICS_BUCKET_SIZE_SECS));
+        int bucketSize = RT.intCast(conf.get(Config.TOPOLOGY_BUILTIN_METRICS_BUCKET_SIZE_SECS));
         String metricBaseName = "cassandra/" + mapStateMetricName;
 		_mreads = context.registerMetric(metricBaseName + "/readCount", new CountMetric(), bucketSize);
         _mwrites = context.registerMetric(metricBaseName + "/writeCount", new CountMetric(), bucketSize);


### PR DESCRIPTION
While testing the code on a Storm 0.9.5 I have been encountering ClassCastExceptions in the registerMetrics method. I changed the cast strategy to be consistent to what I found on other Storm sources and removing the issue.