### PR TITLE
Bump com.datastax.cassandra cassandra-driver-core to 2.1.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>com.datastax.cassandra</groupId>
 			<artifactId>cassandra-driver-core</artifactId>
-			<version>2.1.6</version>
+			<version>2.1.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.cassandraunit</groupId>


### PR DESCRIPTION
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 03:29 min
[INFO] Finished at: 2016-02-15T15:56:22-05:00
[INFO] Final Memory: 26M/138M
[INFO] ------------------------------------------------------------------------
```

## 2.1.7

We've just released version 2.1.7 of the driver, focused on fixes and improvements in the query builder and mapper.

Here are the most notable changes:

- basic mapper operations now accept options to customize the underlying query, for example adding time-to-live (JAVA-477 / JAVA-540), or excluding null fields from the save query (JAVA-473).
- the mapper now also supports computed fields.
- when using protocol v3, the connection pool can now be configured with more than 1 connection (see more explanations here).
- the retry policy has a new tryNextHost decision (JAVA-709).

2.1.7 is binary compatible with 2.1.6. See the upgrade guide for a few non-breaking changes you should be aware of.

Here is the complete changelog:

- [improvement] Improve QueryBuilder API for SELECT DISTINCT (JAVA-475)
- [improvement] Make NativeColumnType a top-level class (JAVA-715)
- [improvement] Unify "Target" enum for schema elements (JAVA-782)
- [improvement] Expose ProtocolVersion#toInt (JAVA-700)
- [bug] Handle void return types in accessors (JAVA-542)
- [improvement] Create values() function for Insert builder using List (JAVA-225)
- [improvement] HashMap throws an OOM Exception when logging level is set to TRACE (JAVA-713)
- [bug] Support bind marker in QueryBuilder DELETE's list index (JAVA-679)
- [improvement] Expose KEYS and FULL indexing options in IndexMetadata (JAVA-732)
- [improvement] Allow @Enumerated in Accessor method parameters (JAVA-589)
- [improvement] Allow access to table metadata from Mapper (JAVA-554)
- [improvement] Provide a way to map computed fields (JAVA-661)
- [improvement] Ignore missing columns in mapper (JAVA-824)
- [bug] Preserve default timestamp for retries and speculative executions (JAVA-724)
- [improvement] Use same pool implementation for protocol v2 and v3
  (JAVA-738).
- [improvement] Support CONTAINS / CONTAINS KEY in QueryBuilder (JAVA-677)
- [improvement] Add USING options in mapper for delete and save
  operations (JAVA-477/JAVA-540)
- [improvement] Add mapper option to configure whether to save null fields (JAVA-473)

Merged from 2.0 branch:

- [bug] DowngradingConsistencyRetryPolicy ignores write timeouts (JAVA-737)
- [bug] Forbid bind marker in QueryBuilder add/append/prepend (JAVA-736)
- [bug] Prevent QueryBuilder.quote() from applying duplicate double quotes (JAVA-712)
- [bug] Prevent QueryBuilder from trying to serialize raw string (JAVA-688)
- [bug] Support bind marker in QueryBuilder DELETE's list index (JAVA-679)
- [improvement] Improve QueryBuilder API for SELECT DISTINCT (JAVA-475)
- [improvement] Create values() function for Insert builder using List (JAVA-225)
- [improvement] Warn when ReplicationStrategy encounters invalid
  replication factors (JAVA-702)
- [improvement] Add PoolingOptions method to set both core and max
  connections (JAVA-662).
- [improvement] Do not include epoll JAR in binary distribution (JAVA-766)
- [improvement] Optimize internal copies of Request objects (JAVA-726)
- [bug] Preserve tracing across retries (JAVA-815)
- [improvement] New RetryDecision.tryNextHost() (JAVA-709)
- [bug] Handle function calls and raw strings as non-idempotent in QueryBuilder (JAVA-733)

## 2.1.7.1

- JAVA-834 caused a metadata parsing error on certain types of indexes in COMPACT STORAGE tables. In particular, this happened when connecting to DataStax Enterprise. This didn't affect any core feature, but would cause repeated warnings in the logs.

- JAVA-835 prevented an accessor query from reusing the same named parameter multiple times, as in the following example:

        @Query("update user set home_phone = :phone, work_phone = :phone where key = :key")
        void updateBothPhones(@Param("key") int key, @Param("phone") String phone);

## 2.1.8

- [improvement] Log streamid at the trace level on sending request and receiving response (JAVA-718)
- [bug] Fix SpeculativeExecutionPolicy.init() and close() are never called (JAVA-796)
- [improvement] Suppress unnecessary warning at shutdown (JAVA-710)
- [improvement] Allow DNS name with multiple A-records as contact point (#340)
- [bug] Allow tracing across multiple result pages (JAVA-794)
- [bug] DowngradingConsistencyRetryPolicy ignores write timeouts (JAVA-737)
- [bug] Forbid bind marker in QueryBuilder add/append/prepend (JAVA-736)
- [bug] Prevent QueryBuilder.quote() from applying duplicate double quotes (JAVA-712)
- [bug] Prevent QueryBuilder from trying to serialize raw string (JAVA-688)
- [bug] Support bind marker in QueryBuilder DELETE's list index (JAVA-679)
- [improvement] Improve QueryBuilder API for SELECT DISTINCT (JAVA-475)
- [improvement] Create values() function for Insert builder using List (JAVA-225)
- [improvement] Warn when ReplicationStrategy encounters invalid
  replication factors (JAVA-702)
- [improvement] Add PoolingOptions method to set both core and max
  connections (JAVA-662).
- [improvement] Do not include epoll JAR in binary distribution (JAVA-766)
- [improvement] Optimize internal copies of Request objects (JAVA-726)
- [bug] Preserve tracing across retries (JAVA-815)
- [improvement] New RetryDecision.tryNextHost() (JAVA-709)
- [bug] Handle function calls and raw strings as non-idempotent in QueryBuilder (JAVA-733)
- [improvement] Provide API to retrieve values of a Parameterized SimpleStatement (JAVA-765)
- [improvement] implement UPDATE ... IF EXISTS in QueryBuilder (JAVA-827)
- [improvement] Randomize contact points list to prevent hotspots (JAVA-618)
- [improvement] Surface the coordinator used on query failure (JAVA-720)
- [bug] Handle contact points removed during init (JAVA-792)
- [improvement] Allow PlainTextAuthProvider to change its credentials at runtime (JAVA-719)
- [new feature] Make it possible to register for SchemaChange Events (JAVA-151)
- [improvement] Downgrade "Asked to rebuild table" log from ERROR to INFO level (JAVA-861)
- [improvement] Provide an option to prepare statements only on one node (JAVA-797)
- [improvement] Provide an option to not re-prepare all statements in onUp (JAVA-658)
- [improvement] Customizable creation of netty timer (JAVA-853)
- [bug] Avoid quadratic ring processing with invalid replication factors (JAVA-859)
- [improvement] Debounce control connection queries (JAVA-657)
- [bug] LoadBalancingPolicy.distance() called before init() (JAVA-784)
- [new feature] Make driver-side metadata optional (JAVA-828)
- [improvement] Allow hosts to remain partially up (JAVA-544)
- [improvement] Remove internal blocking calls and expose async session
  creation (JAVA-821, JAVA-822)
- [improvement] Use parallel calls when re-preparing statement on other
  hosts (JAVA-725)
- [bug] Don't use connection timeout for unrelated internal queries (JAVA-629)
- [bug] Fix NPE in speculative executions when metrics disabled
  (JAVA-892)

## 2.1.9

2.0.12 contains important bug fixes, and a few minor improvements:

- [bug] JAVA-950: Fix Cluster.connect with a case-sensitive keyspace.
- [improvement] JAVA-920: Downgrade "error creating pool" message to WARN.
- [bug] JAVA-954: Don't trigger reconnection before initialization complete.
- [improvement] JAVA-914: Avoid rejected tasks at shutdown.
- [improvement] JAVA-921: Add SimpleStatement.getValuesCount().
- [bug] JAVA-901: Move call to connection.release() out of cancelHandler.
- [bug] JAVA-960: Avoid race in control connection shutdown.
- [bug] JAVA-656: Fix NPE in ControlConnection.updateLocationInfo.
- [bug] JAVA-966: Count uninitialized connections in conviction policy.
- [improvement] JAVA-917: Document SSL configuration.
- [improvement] JAVA-652: Add DCAwareRoundRobinPolicy builder.
- [improvement] JAVA-808: Add generic filtering policy that can be used to exclude specific DCs.

2.1.9 contains all the changes from 2.0.12, and the following tickets:

- [bug] Fix implementation of UserType.hashCode() (JAVA-942)
- [bug] JAVA-854: avoid early return in Cluster.init when a node doesn't support the protocol version.
- [bug] JAVA-978: Fix quoting issue that caused Mapper.getTableMetadata() to return null.
