### PR TITLE
upgrade to storm 1.0.1 / cassandra 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 	</repositories>
 
 	<properties>
-		<storm.version>0.9.1-incubating</storm.version>
+		<storm.version>1.0.1</storm.version>
 		<cassandra.version>1.2.5</cassandra.version>
 	</properties>
 
@@ -88,19 +88,19 @@
 		<dependency>
 			<groupId>org.cassandraunit</groupId>
 			<artifactId>cassandra-unit</artifactId>
-			<version>2.0.2.2</version>
+			<version>3.0.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>16.0.1</version>
+			<version>18.0</version>
 		</dependency>
-                <dependency>
-                    <groupId>net.jpountz.lz4</groupId>
-                    <artifactId>lz4</artifactId>
-                    <version>1.2.0</version>
-                </dependency>
-	</dependencies>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+    </dependencies>
 	<build>
 
 		<plugins>
@@ -139,10 +139,24 @@
                 </plugins>
         </build>
         <profiles>
-             <profile> 
+             <profile>
                  <id>release</id>
                  <build>
                     <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-source-plugin</artifactId>
+                            <version>3.0.0</version>
+                            <executions>
+                                <execution>
+                                    <id>attach-sources</id>
+                                    <phase>verify</phase>
+                                    <goals>
+                                        <goal>jar-no-fork</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
                         <plugin>
                                 <groupId>org.apache.maven.plugins</groupId>
                                 <artifactId>maven-gpg-plugin</artifactId>

--- a/src/main/java/com/hmsonline/trident/cql/CassandraCqlMapState.java
+++ b/src/main/java/com/hmsonline/trident/cql/CassandraCqlMapState.java
@@ -12,15 +12,15 @@ import com.datastax.driver.core.exceptions.WriteFailureException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import storm.trident.state.OpaqueValue;
-import storm.trident.state.StateFactory;
-import storm.trident.state.StateType;
-import storm.trident.state.TransactionalValue;
-import storm.trident.state.map.IBackingMap;
-import backtype.storm.Config;
-import backtype.storm.metric.api.CountMetric;
-import backtype.storm.task.IMetricsContext;
-import backtype.storm.topology.ReportedFailedException;
+import org.apache.storm.trident.state.OpaqueValue;
+import org.apache.storm.trident.state.StateFactory;
+import org.apache.storm.trident.state.StateType;
+import org.apache.storm.trident.state.TransactionalValue;
+import org.apache.storm.trident.state.map.IBackingMap;
+import org.apache.storm.Config;
+import org.apache.storm.metric.api.CountMetric;
+import org.apache.storm.task.IMetricsContext;
+import org.apache.storm.topology.ReportedFailedException;
 
 import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.BatchStatement.Type;

--- a/src/main/java/com/hmsonline/trident/cql/CassandraCqlMapStateFactory.java
+++ b/src/main/java/com/hmsonline/trident/cql/CassandraCqlMapStateFactory.java
@@ -3,17 +3,17 @@ package com.hmsonline.trident.cql;
 import java.util.Map;
 
 import com.datastax.driver.core.Session;
-import storm.trident.state.State;
-import storm.trident.state.StateFactory;
-import storm.trident.state.StateType;
-import storm.trident.state.map.CachedMap;
-import storm.trident.state.map.MapState;
-import storm.trident.state.map.NonTransactionalMap;
-import storm.trident.state.map.OpaqueMap;
-import storm.trident.state.map.SnapshottableMap;
-import storm.trident.state.map.TransactionalMap;
-import backtype.storm.task.IMetricsContext;
-import backtype.storm.tuple.Values;
+import org.apache.storm.trident.state.State;
+import org.apache.storm.trident.state.StateFactory;
+import org.apache.storm.trident.state.StateType;
+import org.apache.storm.trident.state.map.CachedMap;
+import org.apache.storm.trident.state.map.MapState;
+import org.apache.storm.trident.state.map.NonTransactionalMap;
+import org.apache.storm.trident.state.map.OpaqueMap;
+import org.apache.storm.trident.state.map.SnapshottableMap;
+import org.apache.storm.trident.state.map.TransactionalMap;
+import org.apache.storm.task.IMetricsContext;
+import org.apache.storm.tuple.Values;
 
 import com.hmsonline.trident.cql.CassandraCqlMapState.Options;
 import com.hmsonline.trident.cql.mappers.CqlRowMapper;

--- a/src/main/java/com/hmsonline/trident/cql/CassandraCqlState.java
+++ b/src/main/java/com/hmsonline/trident/cql/CassandraCqlState.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import storm.trident.state.State;
+import org.apache.storm.trident.state.State;
 
 import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.BatchStatement.Type;

--- a/src/main/java/com/hmsonline/trident/cql/CassandraCqlStateFactory.java
+++ b/src/main/java/com/hmsonline/trident/cql/CassandraCqlStateFactory.java
@@ -5,9 +5,9 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import storm.trident.state.State;
-import storm.trident.state.StateFactory;
-import backtype.storm.task.IMetricsContext;
+import org.apache.storm.trident.state.State;
+import org.apache.storm.trident.state.StateFactory;
+import org.apache.storm.task.IMetricsContext;
 
 import com.datastax.driver.core.ConsistencyLevel;
 

--- a/src/main/java/com/hmsonline/trident/cql/CassandraCqlStateUpdater.java
+++ b/src/main/java/com/hmsonline/trident/cql/CassandraCqlStateUpdater.java
@@ -6,10 +6,10 @@ import com.hmsonline.trident.cql.mappers.CqlTupleMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import storm.trident.operation.TridentCollector;
-import storm.trident.operation.TridentOperationContext;
-import storm.trident.state.StateUpdater;
-import storm.trident.tuple.TridentTuple;
+import org.apache.storm.trident.operation.TridentCollector;
+import org.apache.storm.trident.operation.TridentOperationContext;
+import org.apache.storm.trident.state.StateUpdater;
+import org.apache.storm.trident.tuple.TridentTuple;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/hmsonline/trident/cql/incremental/CassandraCqlIncrementalState.java
+++ b/src/main/java/com/hmsonline/trident/cql/incremental/CassandraCqlIncrementalState.java
@@ -7,9 +7,9 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import storm.trident.operation.CombinerAggregator;
-import storm.trident.state.State;
-import storm.trident.tuple.TridentTuple;
+import org.apache.storm.trident.operation.CombinerAggregator;
+import org.apache.storm.trident.state.State;
+import org.apache.storm.trident.tuple.TridentTuple;
 
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;

--- a/src/main/java/com/hmsonline/trident/cql/incremental/CassandraCqlIncrementalStateFactory.java
+++ b/src/main/java/com/hmsonline/trident/cql/incremental/CassandraCqlIncrementalStateFactory.java
@@ -5,10 +5,10 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import storm.trident.operation.CombinerAggregator;
-import storm.trident.state.State;
-import storm.trident.state.StateFactory;
-import backtype.storm.task.IMetricsContext;
+import org.apache.storm.trident.operation.CombinerAggregator;
+import org.apache.storm.trident.state.State;
+import org.apache.storm.trident.state.StateFactory;
+import org.apache.storm.task.IMetricsContext;
 
 import com.hmsonline.trident.cql.CqlClientFactory;
 import com.hmsonline.trident.cql.MapConfiguredCqlClientFactory;

--- a/src/main/java/com/hmsonline/trident/cql/incremental/CassandraCqlIncrementalStateUpdater.java
+++ b/src/main/java/com/hmsonline/trident/cql/incremental/CassandraCqlIncrementalStateUpdater.java
@@ -2,10 +2,10 @@ package com.hmsonline.trident.cql.incremental;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import storm.trident.operation.TridentCollector;
-import storm.trident.operation.TridentOperationContext;
-import storm.trident.state.StateUpdater;
-import storm.trident.tuple.TridentTuple;
+import org.apache.storm.trident.operation.TridentCollector;
+import org.apache.storm.trident.operation.TridentOperationContext;
+import org.apache.storm.trident.state.StateUpdater;
+import org.apache.storm.trident.tuple.TridentTuple;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/hmsonline/trident/cql/incremental/CqlIncrementMapper.java
+++ b/src/main/java/com/hmsonline/trident/cql/incremental/CqlIncrementMapper.java
@@ -2,7 +2,7 @@ package com.hmsonline.trident.cql.incremental;
 
 import java.util.List;
 
-import storm.trident.tuple.TridentTuple;
+import org.apache.storm.trident.tuple.TridentTuple;
 
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Statement;

--- a/src/main/java/com/hmsonline/trident/cql/mappers/CqlTupleMapper.java
+++ b/src/main/java/com/hmsonline/trident/cql/mappers/CqlTupleMapper.java
@@ -1,6 +1,6 @@
 package com.hmsonline.trident.cql.mappers;
 
-import storm.trident.tuple.TridentTuple;
+import org.apache.storm.trident.tuple.TridentTuple;
 
 import com.datastax.driver.core.Statement;
 

--- a/src/test/java/com/hmsonline/trident/cql/CassandraCqlStateUpdaterTest.java
+++ b/src/test/java/com/hmsonline/trident/cql/CassandraCqlStateUpdaterTest.java
@@ -3,12 +3,13 @@ package com.hmsonline.trident.cql;
 import com.datastax.driver.core.Statement;
 import com.hmsonline.trident.cql.mappers.CqlTupleMapper;
 import junit.framework.TestCase;
+import org.apache.storm.trident.operation.TridentCollector;
+import org.apache.storm.trident.tuple.TridentTuple;
+import org.apache.storm.trident.tuple.TridentTupleView;
+import org.apache.storm.tuple.Fields;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import storm.trident.operation.TridentCollector;
-import storm.trident.testing.MockTridentTuple;
-import storm.trident.tuple.TridentTuple;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,9 +35,7 @@ public class CassandraCqlStateUpdaterTest extends TestCase {
 
 	private List<TridentTuple> getTridentTuples() {
 		List<TridentTuple> tuples = new ArrayList<TridentTuple>();
-		List<String> mockFieldList = new ArrayList<String>();
-		mockFieldList.add("testField");
-		TridentTuple tuple = new MockTridentTuple(mockFieldList, "testValue");
+		TridentTuple tuple = TridentTupleView.createFreshTuple(new Fields("testField"), "testValue");
 		tuples.add(tuple);
 		return tuples;
 	}

--- a/src/test/java/com/hmsonline/trident/cql/example/sales/SalesEmitter.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/sales/SalesEmitter.java
@@ -1,8 +1,8 @@
 package com.hmsonline.trident.cql.example.sales;
 
-import storm.trident.operation.TridentCollector;
-import storm.trident.spout.ITridentSpout.Emitter;
-import storm.trident.topology.TransactionAttempt;
+import org.apache.storm.trident.operation.TridentCollector;
+import org.apache.storm.trident.spout.ITridentSpout.Emitter;
+import org.apache.storm.trident.topology.TransactionAttempt;
 
 import java.io.Serializable;
 import java.util.ArrayList;

--- a/src/test/java/com/hmsonline/trident/cql/example/sales/SalesMapper.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/sales/SalesMapper.java
@@ -7,7 +7,7 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
 import java.io.Serializable;
 import java.util.List;
 
-import storm.trident.tuple.TridentTuple;
+import org.apache.storm.trident.tuple.TridentTuple;
 
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Statement;

--- a/src/test/java/com/hmsonline/trident/cql/example/sales/SalesSpout.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/sales/SalesSpout.java
@@ -1,12 +1,12 @@
 package com.hmsonline.trident.cql.example.sales;
 
-import backtype.storm.spout.SpoutOutputCollector;
-import backtype.storm.task.TopologyContext;
-import backtype.storm.tuple.Fields;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.tuple.Fields;
 
 import com.hmsonline.trident.cql.example.simpleupdate.DefaultCoordinator;
 
-import storm.trident.spout.ITridentSpout;
+import org.apache.storm.trident.spout.ITridentSpout;
 
 import java.util.Map;
 

--- a/src/test/java/com/hmsonline/trident/cql/example/sales/SalesTopology.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/sales/SalesTopology.java
@@ -6,13 +6,13 @@ import org.junit.Rule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import storm.trident.Stream;
-import storm.trident.TridentTopology;
-import storm.trident.operation.builtin.Sum;
-import backtype.storm.Config;
-import backtype.storm.LocalCluster;
-import backtype.storm.generated.StormTopology;
-import backtype.storm.tuple.Fields;
+import org.apache.storm.trident.Stream;
+import org.apache.storm.trident.TridentTopology;
+import org.apache.storm.trident.operation.builtin.Sum;
+import org.apache.storm.Config;
+import org.apache.storm.LocalCluster;
+import org.apache.storm.generated.StormTopology;
+import org.apache.storm.tuple.Fields;
 
 import com.hmsonline.trident.cql.MapConfiguredCqlClientFactory;
 import com.hmsonline.trident.cql.incremental.CassandraCqlIncrementalStateFactory;

--- a/src/test/java/com/hmsonline/trident/cql/example/simpleupdate/DefaultCoordinator.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/simpleupdate/DefaultCoordinator.java
@@ -2,7 +2,7 @@ package com.hmsonline.trident.cql.example.simpleupdate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import storm.trident.spout.ITridentSpout.BatchCoordinator;
+import org.apache.storm.trident.spout.ITridentSpout.BatchCoordinator;
 
 import java.io.Serializable;
 

--- a/src/test/java/com/hmsonline/trident/cql/example/simpleupdate/SimpleUpdateEmitter.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/simpleupdate/SimpleUpdateEmitter.java
@@ -1,8 +1,8 @@
 package com.hmsonline.trident.cql.example.simpleupdate;
 
-import storm.trident.operation.TridentCollector;
-import storm.trident.spout.ITridentSpout.Emitter;
-import storm.trident.topology.TransactionAttempt;
+import org.apache.storm.trident.operation.TridentCollector;
+import org.apache.storm.trident.spout.ITridentSpout.Emitter;
+import org.apache.storm.trident.topology.TransactionAttempt;
 
 import java.io.Serializable;
 import java.util.ArrayList;

--- a/src/test/java/com/hmsonline/trident/cql/example/simpleupdate/SimpleUpdateMapper.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/simpleupdate/SimpleUpdateMapper.java
@@ -6,7 +6,7 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
 
 import java.io.Serializable;
 
-import storm.trident.tuple.TridentTuple;
+import org.apache.storm.trident.tuple.TridentTuple;
 
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Statement;

--- a/src/test/java/com/hmsonline/trident/cql/example/simpleupdate/SimpleUpdateSpout.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/simpleupdate/SimpleUpdateSpout.java
@@ -1,9 +1,9 @@
 package com.hmsonline.trident.cql.example.simpleupdate;
 
-import backtype.storm.spout.SpoutOutputCollector;
-import backtype.storm.task.TopologyContext;
-import backtype.storm.tuple.Fields;
-import storm.trident.spout.ITridentSpout;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.trident.spout.ITridentSpout;
 
 import java.util.Map;
 

--- a/src/test/java/com/hmsonline/trident/cql/example/simpleupdate/SimpleUpdateTopology.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/simpleupdate/SimpleUpdateTopology.java
@@ -3,12 +3,12 @@ package com.hmsonline.trident.cql.example.simpleupdate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import storm.trident.Stream;
-import storm.trident.TridentTopology;
-import backtype.storm.Config;
-import backtype.storm.LocalCluster;
-import backtype.storm.generated.StormTopology;
-import backtype.storm.tuple.Fields;
+import org.apache.storm.trident.Stream;
+import org.apache.storm.trident.TridentTopology;
+import org.apache.storm.Config;
+import org.apache.storm.LocalCluster;
+import org.apache.storm.generated.StormTopology;
+import org.apache.storm.tuple.Fields;
 
 import com.datastax.driver.core.ConsistencyLevel;
 import com.hmsonline.trident.cql.CassandraCqlStateFactory;

--- a/src/test/java/com/hmsonline/trident/cql/example/wordcount/IntegerCount.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/wordcount/IntegerCount.java
@@ -1,7 +1,7 @@
 package com.hmsonline.trident.cql.example.wordcount;
 
-import storm.trident.operation.CombinerAggregator;
-import storm.trident.tuple.TridentTuple;
+import org.apache.storm.trident.operation.CombinerAggregator;
+import org.apache.storm.trident.tuple.TridentTuple;
 
 
 public class IntegerCount implements CombinerAggregator<Integer> {

--- a/src/test/java/com/hmsonline/trident/cql/example/wordcount/WordCountAndSourceMapper.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/wordcount/WordCountAndSourceMapper.java
@@ -3,7 +3,7 @@ package com.hmsonline.trident.cql.example.wordcount;
 import java.io.Serializable;
 import java.util.List;
 
-import storm.trident.tuple.TridentTuple;
+import org.apache.storm.trident.tuple.TridentTuple;
 
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Statement;

--- a/src/test/java/com/hmsonline/trident/cql/example/wordcount/WordCountTopology.java
+++ b/src/test/java/com/hmsonline/trident/cql/example/wordcount/WordCountTopology.java
@@ -1,22 +1,22 @@
 package com.hmsonline.trident.cql.example.wordcount;
 
-import backtype.storm.Config;
-import backtype.storm.LocalCluster;
-import backtype.storm.LocalDRPC;
-import backtype.storm.generated.StormTopology;
-import backtype.storm.tuple.Fields;
-import backtype.storm.tuple.Values;
+import org.apache.storm.Config;
+import org.apache.storm.LocalCluster;
+import org.apache.storm.LocalDRPC;
+import org.apache.storm.generated.StormTopology;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Values;
 import com.hmsonline.trident.cql.CassandraCqlMapState;
 import com.hmsonline.trident.cql.MapConfiguredCqlClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import storm.trident.TridentState;
-import storm.trident.TridentTopology;
-import storm.trident.operation.builtin.FilterNull;
-import storm.trident.operation.builtin.MapGet;
-import storm.trident.operation.builtin.Sum;
-import storm.trident.testing.FixedBatchSpout;
-import storm.trident.testing.Split;
+import org.apache.storm.trident.TridentState;
+import org.apache.storm.trident.TridentTopology;
+import org.apache.storm.trident.operation.builtin.FilterNull;
+import org.apache.storm.trident.operation.builtin.MapGet;
+import org.apache.storm.trident.operation.builtin.Sum;
+import org.apache.storm.trident.testing.FixedBatchSpout;
+import org.apache.storm.trident.testing.Split;
 
 public class WordCountTopology {
     private static final Logger LOG = LoggerFactory.getLogger(WordCountTopology.class);


### PR DESCRIPTION
This upgrades storm-cassandra-cql to the current release of apache storm 1.0.1.

All unit tests pass.   Had to upgrade guava and add commons due to dependency issues.
